### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dicvm/9283cf32-20bc-4c18-908d-b3f8ec5ad441/a70790aa-0861-4989-ab18-e42b32e9b418/_apis/work/boardbadge/0d25ee81-ca30-4829-919b-929be28f8a74)](https://dev.azure.com/dicvm/9283cf32-20bc-4c18-908d-b3f8ec5ad441/_boards/board/t/a70790aa-0861-4989-ab18-e42b32e9b418/Microsoft.RequirementCategory)
 # .github
 
 See ```profile``` for the organization Page


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/dicvm/9283cf32-20bc-4c18-908d-b3f8ec5ad441/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.